### PR TITLE
Module 3: Docker

### DIFF
--- a/mod3/hello-docker/Dockerfile
+++ b/mod3/hello-docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.18
+
+WORKDIR /app
+
+ENV COUNT 8
+ENV MSG 'Hello Docker!'
+
+COPY ./echo.sh .
+COPY ./lucas.sh .
+
+CMD /app/lucas.sh && /app/echo.sh 

--- a/mod3/hello-docker/echo.sh
+++ b/mod3/hello-docker/echo.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo $MSG

--- a/mod3/hello-docker/lucas.sh
+++ b/mod3/hello-docker/lucas.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# lucas series
+if [ -z "$COUNT" ]
+then
+    /bin/echo -n "COUNT is empty"
+else
+    N=$COUNT
+    a=2
+    b=1  
+    i=0
+    while [ "$i" -lt "$N" ] 
+    do
+        /bin/echo -n "$a "
+        fn=$(( a + b )) 
+        a=$b
+        b=$fn
+        i=$(( i + 1 ))
+    done
+fi

--- a/mod3/python-env/Dockerfile
+++ b/mod3/python-env/Dockerfile
@@ -1,0 +1,8 @@
+ARG PYTHON_VERSION=3.10
+FROM python:${PYTHON_VERSION}-slim
+
+RUN pip3 install nbmake
+RUN pip3 install pytest
+RUN pip3 install pylint
+
+WORKDIR /app


### PR DESCRIPTION
This module consisted of using Dockerfiles for different purposes. In the first part, the Dockerfile instructs the container runtime to copy two shell scripts into the image, which are eventually called as part of the default command when the image is run as a container.

In the second part, the Dockerfile instructs the container runtime to build an image which is based on a specified python version which is given as a build argument during build time (default is 3.10). The image can be run as a container, and is able to build, test and lint python application code.